### PR TITLE
Add option "defaultInput" to all keyIn* methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,7 +408,6 @@ file = readlineSync.question('Name of Text File :', {
 
 ### <a name="basic_options-defaultinput"></a>`defaultInput`
 
-_For `question*` and `prompt*` methods only_  
 *Type:* string  
 *Default:* `''`
 
@@ -1279,7 +1278,7 @@ if (readlineSync.keyInYN('Continue virus scan?') === false) {
 The following options work as shown in the [Basic Options](#basic_options) section.
 
 <table>
-<tr><td><a href="#basic_options-encoding"><code>encoding</code></a></td><td><a href="#basic_options-print"><code>print</code></a></td></tr>
+<tr><td><a href="#basic_options-defaultinput"><code>defaultInput</code></a></td><td><a href="#basic_options-encoding"><code>encoding</code></a></td><td><a href="#basic_options-print"><code>print</code></a></td></tr>
 </table>
 
 And the following additional option is available.
@@ -1365,7 +1364,7 @@ The following option has independent default value that is not affected by [Defa
 The following options work as shown in the [Basic Options](#basic_options) section.
 
 <table>
-<tr><td><a href="#basic_options-casesensitive"><code>caseSensitive</code></a></td><td><a href="#basic_options-encoding"><code>encoding</code></a></td><td><a href="#basic_options-print"><code>print</code></a></td></tr>
+<tr><td><a href="#basic_options-casesensitive"><code>caseSensitive</code></a></td><td><a href="#basic_options-defaultinput"><code>defaultInput</code></a></td><td><a href="#basic_options-encoding"><code>encoding</code></a></td><td><a href="#basic_options-print"><code>print</code></a></td></tr>
 </table>
 
 And the following additional option is available.
@@ -1431,7 +1430,7 @@ The following option has independent default value that is not affected by [Defa
 The following options work as shown in the [Basic Options](#basic_options) section.
 
 <table>
-<tr><td><a href="#basic_options-mask"><code>mask</code></a></td><td><a href="#basic_options-encoding"><code>encoding</code></a></td><td><a href="#basic_options-print"><code>print</code></a></td></tr>
+<tr><td><a href="#basic_options-mask"><code>mask</code></a></td><td><a href="#basic_options-defaultinput"><code>defaultInput</code></a></td><td><a href="#basic_options-encoding"><code>encoding</code></a></td><td><a href="#basic_options-print"><code>print</code></a></td></tr>
 </table>
 
 And the following additional options are available.

--- a/lib/readline-sync.js
+++ b/lib/readline-sync.js
@@ -217,6 +217,10 @@ function _readlineSync(options) {
         input += chunk;
       }
 
+      if (options.defaultInput.length && !input.length && atEol) {
+        input = options.defaultInput;
+      }
+
       if (!options.keyIn && atEol ||
         options.keyIn && input.length >= reqSize) { break; }
     }
@@ -1165,8 +1169,17 @@ function _keyInYN(query, options, limit) {
   /* jshint eqnull:true */
   if (query == null) { query = 'Are you sure? :'; }
   /* jshint eqnull:false */
-  if ((!options || options.guide !== false) && (query += ''))
-    { query = query.replace(/\s*:?\s*$/, '') + ' [y/n] :'; }
+  if (options && options.defaultInput) {
+    options.defaultInput = options.defaultInput.toLowerCase();
+    if (options.defaultInput !== 'y' && options.defaultInput !== 'n') {
+      options.defaultInput = undefined;
+    }
+  }
+  if ((!options || options.guide !== false || options.defaultInput) && (query += '')) {
+    query = query.replace(/\s*:?\s*$/, '') + ' [';
+    query += (options && options.defaultInput === 'y' ? 'Y' : 'y') + '/';
+    query += (options && options.defaultInput === 'n' ? 'N' : 'n') + '] :';
+  }
   res = exports.keyIn(query, margeOptions(options, {
       // -------- forced
       hideEchoBack:       false,
@@ -1218,7 +1231,9 @@ exports.keyInSelect = function(items, query, options) {
         }
     }),
     // added:     guide, cancel
-    keylist = '', key2i = {}, charCode = 49 /* '1' */, display = '\n';
+    keylist = '', key2i = {}, charCode = 49 /* '1' */, display = '\n',
+    defaultInput = options && '' + options.defaultInput;
+
   if (!Array.isArray(items) || !items.length || items.length > 35)
     { throw '`items` must be Array (max length: 35).'; }
 
@@ -1226,17 +1241,22 @@ exports.keyInSelect = function(items, query, options) {
     var key = String.fromCharCode(charCode);
     keylist += key;
     key2i[key] = i;
+    display += (key === defaultInput ? '*' : ' ');
     display += '[' + key + '] ' + (item + '').trim() + '\n';
     charCode = charCode === 57 /* '9' */ ? 97 /* 'a' */ : charCode + 1;
   });
   if (!options || options.cancel !== false) {
     keylist += '0';
     key2i['0'] = -1;
+    display += (defaultInput === '0' ? '*' : ' ');
     /* jshint eqnull:true */
     display += '[' + '0' + '] ' +
       (options && options.cancel != null && typeof options.cancel !== 'boolean' ?
         (options.cancel + '').trim() : 'CANCEL') + '\n';
     /* jshint eqnull:false */
+  }
+  if (key2i[defaultInput] === undefined) {
+    readOptions.defaultInput = undefined;
   }
   readOptions.limit = keylist;
   display += '\n';


### PR DESCRIPTION
I found a lack of option 'defaultInput' in all KeyIn* methods and improved it. It works fine for all four methods, even for keyInSelect. Notice that default input is marked in all methods (except for keyInPause)