### PR TITLE
Accept Enter key in keyInPause

### DIFF
--- a/lib/readline-sync.js
+++ b/lib/readline-sync.js
@@ -38,7 +38,8 @@ var
     history:            true,
     cd:                 false,
     phContent:          void 0,
-    preCheck:           void 0
+    preCheck:           void 0,
+    allowEmpty:         false,
     /* eslint-enable key-spacing */
   },
 
@@ -413,8 +414,10 @@ function _readlineSync(options) {
         input += chunk;
       }
 
-      if (!options.keyIn && atEol ||
-        options.keyIn && input.length >= reqSize) { break; }
+      if (
+        (!options.keyIn || options.allowEmpty) && atEol ||
+        options.keyIn && input.length >= reqSize
+      ) { break; }
     }
 
     if (!isCooked && !silent) { fs.writeSync(fdW, '\n'); }
@@ -513,6 +516,7 @@ function margeOptions() {
         case 'keepWhitespace':              // *    *
         case 'history':                     //      *
         case 'cd':                          //      *
+        case 'allowEmpty':                  // *    *
           options[optionName] = !!value;
           break;
         // ================ array
@@ -1228,7 +1232,8 @@ exports.keyInPause = function(query, options) {
   }, options, {
     // -------- forced
     hideEchoBack:       true,
-    mask:               ''
+    mask:               '',
+    allowEmpty:         true,
   }));
   // added:     guide
   /* eslint-enable key-spacing */


### PR DESCRIPTION
    readlineSync.keyInPause('All done.');

generates a line that reads:

    All done. (Hit any key)

Before this commit, the Enter key was not accepted to continue from the
prompt. This could be a surprise for many users who naturally hit Enter
when they are prompted to hit any key. This commit makes it so
`keyInPause` accepts Enter, while being careful to not break other
`keyIn` methods.

`keyIn` accepts an option, `limit`, which makes it so that when
prompted, the program will not continue until the user has hit one of
the keys specified in `limit`. A previous commit, 6dffd8, made sure that
Enter was not accepted in any `keyIn` method so that the user could not
accidentally circumvent a `keyIn` with `limit` set.  This commit
introduces a new private option, `allowEmpty`. When and only when
`allowEmpty` is set to true, `keyIn` will accept Enter. `keyInPause` sets
this new option to `true`, allowing the user to hit Enter to move past a
`keyInPause` prompt.

Outside of `keyInPause`, `allowEmpty` defaults to false. This
`allowEmpty` option is not documented because it only makes sense in the
`keyInPause` scenario.