### PR TITLE
possible fix for console redict node.js crash

### DIFF
--- a/lib/readline-sync.js
+++ b/lib/readline-sync.js
@@ -263,18 +263,7 @@ function _readlineSync(options) {
   if (_DBG_checkOptions) { _DBG_checkOptions(options); }
 
   (function() { // open TTY
-    var fsB, constants, verNum;
-
-    function getFsB() {
-      if (!fsB) {
-        fsB = process.binding('fs'); // For raw device path
-        constants = process.binding('constants');
-        // for v6.3.0+
-        constants = constants && constants.fs && typeof constants.fs.O_RDWR === 'number'
-          ? constants.fs : constants;
-      }
-      return fsB;
-    }
+    var verNum;
 
     if (typeof fdR !== 'string') { return; }
     fdR = null;
@@ -302,22 +291,21 @@ function _readlineSync(options) {
         try {
           // The stream by fs.openSync('\\\\.\\CON', 'r') can't switch to raw mode.
           // 'CONIN$' might fail on XP, 2000, 7 (x86).
-          fdR = getFsB().open('CONIN$', constants.O_RDWR, parseInt('0666', 8));
+          fdR = fs.openSync(Buffer.from('CONIN$'), "r"); 
           ttyR = new TTY(fdR, true);
-        } catch (e) { /* ignore */ }
+        } catch (e) {
+	    console.error(":readline-sync-conin-create-error %s", e);
+	}
       }
 
       if (process.stdout.isTTY) {
         fdW = process.stdout.fd;
       } else {
         try {
-          fdW = fs.openSync('\\\\.\\CON', 'w');
-        } catch (e) { /* ignore */ }
-        if (typeof fdW !== 'number') { // Retry
-          try {
-            fdW = getFsB().open('CONOUT$', constants.O_RDWR, parseInt('0666', 8));
-          } catch (e) { /* ignore */ }
-        }
+          fdW = fs.openSync(Buffer.from('CONOUT$'), 'r+');
+        } catch (e) {
+	    console.error(":readline-sync-conout-create-error %s", e);
+	}
       }
 
     } else {


### PR DESCRIPTION
please consider this patch as a potential option for fixing the node.js console redirect crash described in issue#94.

It gets away from node.js' c++ fs interface in favour of the internal node.js fs module.

I have not used readlib-sync directly before, so I don't have any good understanding of the internals, other than looking around to find the root cause for the crash and suggest a possible solution.

I have manually tested this to work on the windows 10 command prompt using the following command, which redirect both input and output from/to the corresponding files.

`: node.exe  -e "console.log(':r', require('./node_modules/readline-sync/lib/readline-sync.js').keyInYN('t'))" < empty.txt > out.txt`

The output in out.txt is:

When pressing y -> :r true
When pressing n -> :r false
When pressing any other key -> :r 

which is with conformance with the KeyIn interface @ https://github.com/anseki/readline-sync#utility_methods-keyinyn :

> A return value means "Yes" or "No" the user said. It differ depending on the pressed key:
> 
>     Y: true
>     N: false
>     other: ''

Thanks